### PR TITLE
Add Spanish translation

### DIFF
--- a/WowUp.toc
+++ b/WowUp.toc
@@ -19,6 +19,8 @@ locales/enUS.lua
 locales/deDE.lua
 locales/ruRU.lua
 locales/itIT.lua
+locales/esES.lua
+locales/esMX.lua
 
 util.lua
 ldbicon.lua

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -1,0 +1,19 @@
+-- esES localization
+local L = LibStub("AceLocale-3.0"):NewLocale("WOWUP", "esES", true, true)
+
+-- Nota al traductor: La interfaz del juego utiliza Addon para los Complementos/Accesorios
+--      por tanto, el traductor original ha decidido utilizar la misma palabra para así
+--      mantener consistencia, si el juego llegase a cambiarla (que ya ha hecho antes)
+--      haced el cambio también, y recuerdad que esta es la versión _Europea_
+
+L["Notification"] = "Notificación"
+L["You have %d addon to be updated"] = "Tienes %d addon que actualizar"
+L["You have %d addons to be updated"] = "Tienes %d addons que actualizar"
+L["All addons are up-to-date"] = "Todos los addons están actualizados"
+L["Show a popup with a notification after loading when updates are available"] = "Muestra una ventana emergente con una notificación después de cargar cuando haya actualizaciones disponibles"
+L["Show a chat message indicating whether or not updates are available"] = "Muestra un mensaje de chat indicando si hay o no actualizaciones disponibles"
+L["Click to open settings"] = "Haz clic para abrir la configuración"
+L["Show a list of all addons to be updated in a popup notification"] = "Muestra una lista de todos los addons que se actualizarán en una notificación emergente"
+L["Show a list of all addons to be updated in a chat message"] = "Muestra una lista de todos los addons que se actualizarán en un mensaje de chat"
+L["Show Minimap icon"] = "Muestra icono del minimapa"
+L["Data addon is missing"] = "Faltan datos del addon"

--- a/locales/esES.lua
+++ b/locales/esES.lua
@@ -1,5 +1,6 @@
 -- esES localization
-local L = LibStub("AceLocale-3.0"):NewLocale("WOWUP", "esES", true, true)
+local L = LibStub("AceLocale-3.0"):NewLocale("WOWUP", "esES")
+if not L then return end
 
 -- Nota al traductor: La interfaz del juego utiliza Addon para los Complementos/Accesorios
 --      por tanto, el traductor original ha decidido utilizar la misma palabra para así

--- a/locales/esMX.lua
+++ b/locales/esMX.lua
@@ -1,5 +1,6 @@
 -- esMX localization
-local L = LibStub("AceLocale-3.0"):NewLocale("WOWUP", "esMX", true, true)
+local L = LibStub("AceLocale-3.0"):NewLocale("WOWUP", "esMX")
+if not L then return end
 
 -- Nota al traductor: La interfaz del juego utiliza Accesorio para los Add-Ons/Complementos
 --      por tanto, el traductor original ha decidido usar la misma palabra usada para

--- a/locales/esMX.lua
+++ b/locales/esMX.lua
@@ -1,0 +1,19 @@
+-- esMX localization
+local L = LibStub("AceLocale-3.0"):NewLocale("WOWUP", "esMX", true, true)
+
+-- Nota al traductor: La interfaz del juego utiliza Accesorio para los Add-Ons/Complementos
+--      por tanto, el traductor original ha decidido usar la misma palabra usada para
+--      mantener la consistencia, si el juego la llega a cambiar (que ya ha hecho antes)
+--      hacer el cambio también, y recuerde que esta es la versión _Latinoamericana_
+
+L["Notification"] = "Notificación"
+L["You have %d addon to be updated"] = "Tiene %d accesorio que actualizar"
+L["You have %d addons to be updated"] = "Tiene %d accesorios que actualizar"
+L["All addons are up-to-date"] = "Todos los accesorios están actualizados"
+L["Show a popup with a notification after loading when updates are available"] = "Mostrar una ventana emergente con una notificación después de cargar cuando haya actualizaciones disponibles"
+L["Show a chat message indicating whether or not updates are available"] = "Mostrar un mensaje de chat indicando si hay actualizaciones disponibles o no"
+L["Click to open settings"] = "Haga clic para abrir la configuración"
+L["Show a list of all addons to be updated in a popup notification"] = "Mostrar una lista de todos los accesorios que se actualizarán en una notificación emergente"
+L["Show a list of all addons to be updated in a chat message"] = "Mostrar una lista de todos los accesorios que se actualizarán en un mensaje de chat"
+L["Show Minimap icon"] = "Mostrar icono junto al minimapa"
+L["Data addon is missing"] = "Faltan datos del accesorio"


### PR DESCRIPTION
This add both Latinamerican AND European spanish, it also use the same words that are used in-game for both for they respective language versions

I'm doing it right?