### PR TITLE
 decode html entities in Addon Names

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -24,7 +24,7 @@ local function frame_OnEvent(self, event, ...)
             if WowUpAddonInformation.showChatNotificationList and WOWUP_DATA.updateAddonsList then
                 for k, v in pairs(WOWUP_DATA.updateAddonsList) do
                     if type(v) == "table" then
-                        local addonLine = k .. ": "-- add AddonName
+                        local addonLine = WOWUP.DecodeHTMLEntities(k) .. ": " -- add AddonName
                         addonLine = addonLine .. WOWUP.CreateRGBToHex(GRAY_FONT_COLOR.r, GRAY_FONT_COLOR.g, GRAY_FONT_COLOR.b) .. (v[1] and v[1] or " ") .. "|r " -- current version
                         addonLine = addonLine .. WOWUP.CreateRGBToHex(r, g, b) .. "-> " .. (v[2] and v[2] or " ") .. "|r "
                         DEFAULT_CHAT_FRAME:AddMessage(addonLine)
@@ -43,7 +43,7 @@ local function frame_OnEvent(self, event, ...)
             local addonUpdateList = "\n\n"
             for k, v in pairs(WOWUP_DATA.updateAddonsList) do
                 if type(v) == "table" then
-                    local addonLine = k .. ": "-- add AddonName
+                    local addonLine = WOWUP.DecodeHTMLEntities(k) .. ": " -- add AddonName
                     addonLine = addonLine .. WOWUP.CreateRGBToHex(GRAY_FONT_COLOR.r, GRAY_FONT_COLOR.g, GRAY_FONT_COLOR.b) .. (v[1] and v[1] or " ") .. "|r " -- current version
                     addonLine = addonLine .. WOWUP.CreateRGBToHex(r, g, b) .. "-> " .. (v[2] and v[2] or " ") .. "|r "
                     addonUpdateList = addonUpdateList .. addonLine .. "\n"

--- a/util.lua
+++ b/util.lua
@@ -41,6 +41,30 @@ local function CreateRGBToHex(r, g, b)
 end
 WOWUP.CreateRGBToHex = CreateRGBToHex
 
+local function DecodeHTMLEntities(str)
+    if type(str) ~= "string" then return str end
+    -- named entities
+    str = str:gsub("&amp;",   "&")
+    str = str:gsub("&lt;",    "<")
+    str = str:gsub("&gt;",    ">")
+    str = str:gsub("&quot;",  '"')
+    str = str:gsub("&apos;",  "'")
+    str = str:gsub("&#39;",   "'")
+    str = str:gsub("&nbsp;",  " ")
+    str = str:gsub("&ndash;", "–")
+    str = str:gsub("&mdash;", "—")
+    -- decimal numeric entities  &#123;
+    str = str:gsub("&#(%d+);", function(n)
+        return string.char(tonumber(n))
+    end)
+    -- hex numeric entities  &#x1F;
+    str = str:gsub("&#x(%x+);", function(h)
+        return string.char(tonumber(h, 16))
+    end)
+    return str
+end
+WOWUP.DecodeHTMLEntities = DecodeHTMLEntities
+
 local function CountTable(T)
     local c = 0
     if T ~= nil and type(T) == "table" then


### PR DESCRIPTION
Addon names can look garbled in the notification window in wow:
`DBM - Dungeons, Delves, Visions, &amp; Events (Requires Deadly Boss Mods) - DBM`

This removes the encoding before displaying the addon name. Alternatively this can also be filtered before writing the data-addon.
